### PR TITLE
ENG-4101: Apply pts_adjustment to splice times in HLS and DASH handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ gradle-app.setting
 debug/logs
 debug/tmp
 /.idea/
+CLAUDE.local.md

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'com.wowza.wms.plugin.scte'
-version '1.1.2'
+version '1.1.3'
 
 java {
     toolchain {

--- a/src/main/java/com/wowza/wms/plugin/scte/LiveStreamPacketizerCupertinoDataHandlerCue.java
+++ b/src/main/java/com/wowza/wms/plugin/scte/LiveStreamPacketizerCupertinoDataHandlerCue.java
@@ -34,7 +34,7 @@ public class LiveStreamPacketizerCupertinoDataHandlerCue extends LiveStreamPacke
                     if (!spliceOut)
                         return null;
                     AMFDataObj spliceTimeObj = eventObj.getObject("spliceTime");
-                    long spliceTimecode = spliceTimeObj.getLong("spliceTimeMS");
+                    long spliceTimecode = spliceTimeObj.getLong("spliceTimeMS") + (data.getLong("ptsAdjustment") / 90);
                     boolean durationFlag = eventObj.getBoolean("durationFlag");
                     long breakDuration = durationFlag ? (long) (eventObj.getDouble("breakDuration") / 90) : 0L;
                     if (breakDuration <= 0)

--- a/src/main/java/com/wowza/wms/plugin/scte/LiveStreamPacketizerCupertinoDataHandlerDateRange.java
+++ b/src/main/java/com/wowza/wms/plugin/scte/LiveStreamPacketizerCupertinoDataHandlerDateRange.java
@@ -46,12 +46,13 @@ public class LiveStreamPacketizerCupertinoDataHandlerDateRange extends LiveStrea
 				AMFDataObj eventObj = commandObj.getObject("event");
 				long eventId = eventObj.getLong("eventID");
 				boolean spliceOut = eventObj.getBoolean("outOfNetwork");
-				if (spliceOut) 
+				long ptsAdjustmentMs = data.getLong("ptsAdjustment") / 90;
+				if (spliceOut)
 				{
 					events.computeIfAbsent(eventId, id -> {
 						currentEventId.set(id);
 						AMFDataObj spliceTimeObj = eventObj.getObject("spliceTime");
-						long spliceTimecode = spliceTimeObj.getLong("spliceTimeMS");
+						long spliceTimecode = spliceTimeObj.getLong("spliceTimeMS") + ptsAdjustmentMs;
 						boolean durationFlag = eventObj.getBoolean("durationFlag");
 						long breakDuration = durationFlag ? (long) (eventObj.getDouble("breakDuration") / 90) : 0L;
 						OnDataEvent newEvent = new OnDataEvent(id);
@@ -66,7 +67,7 @@ public class LiveStreamPacketizerCupertinoDataHandlerDateRange extends LiveStrea
 				{
 					events.computeIfPresent(currentEventId.get(), (id, event) -> {
 						AMFDataObj spliceTimeObj = eventObj.getObject("spliceTime");
-						long spliceTimecode = spliceTimeObj.getLong("spliceTimeMS");
+						long spliceTimecode = spliceTimeObj.getLong("spliceTimeMS") + ptsAdjustmentMs;
 						long breakDuration =  spliceTimecode - event.startTime;
 						if (breakDuration > 0) 
 							event.duration = breakDuration;

--- a/src/main/java/com/wowza/wms/plugin/scte/LiveStreamPacketizerMpegDashDataHandler.java
+++ b/src/main/java/com/wowza/wms/plugin/scte/LiveStreamPacketizerMpegDashDataHandler.java
@@ -86,7 +86,8 @@ public class LiveStreamPacketizerMpegDashDataHandler extends LiveStreamPacketize
                         long presentationTime = -1;
                         if (!isUTC && spliceTimeObj.containsKey("spliceTimeMS"))
                             spliceTime = spliceTimeObj.getLong("spliceTimeMS") * 90;
-                            presentationTime = spliceTime;
+                        spliceTime += data.getLong("ptsAdjustment");
+                        presentationTime = spliceTime;
                         long duration = -1;
                         if (eventObj.getBoolean("durationFlag") && eventObj.containsKey("breakDuration"))
                             duration = (long) eventObj.getDouble("breakDuration");


### PR DESCRIPTION
## Summary

- Fixes [ENG-4101](https://wowzamedia.jira.com/browse/ENG-4101): the SCTE-35 splice_info_section `pts_adjustment` field was being ignored, so HLS (`EXT-X-DATERANGE` / `EXT-X-CUE-OUT`) and DASH (`<EventStream>`) ad markers — and the `setSegmentStopKeyTimecode` boundary alignment that goes with them — landed at `splice_time` instead of the true PTS (`splice_time + pts_adjustment`).
- WSE already publishes `ptsAdjustment` (90 kHz ticks) at the root of the SCTE AMF object via `SpliceInformationTable#toAMFData`. The fix reads it once per event and adds `ptsAdjustment / 90` to `spliceTimeMS` in the two HLS handlers, and `ptsAdjustment` directly (already 90 kHz) to `spliceTime` in the DASH handler.
- End boundaries (`event.startTime + event.duration`) automatically pick up the correction since `startTime` is now adjusted at capture.
- Drive-by: bumps plugin version to 1.1.3 and adds `CLAUDE.local.md` to `.gitignore`.

## Test plan

- [ ] Build with `./gradlew build` — verified locally, BUILD SUCCESSFUL.
- [ ] Manifest correctness with a feed whose SCTE-35 carries non-zero `pts_adjustment`: confirm `EXT-X-DATERANGE` `START-DATE` (DATERANGE mode), `EXT-X-CUE-OUT` / `EXT-X-CUE-OUT-CONT` / `EXT-X-CUE-IN` timings (CUE mode), and DASH `<Event presentationTime>` all match the true splice point.
- [ ] Confirm the segment boundary in the HLS playlist / DASH manifest is on the corrected splice point (i.e. `setSegmentStopKeyTimecode` truncation aligned with the marker).
- [ ] Regression: with `pts_adjustment = 0`, output matches the previous release byte-for-byte (sanity).
- [ ] Verify `EXT-X-CUE-IN` / DASH event end (`startTime + duration`) also lands at the corrected time.
- [ ] Cover both HLS modes (`scteAdsHlsTagType=DATERANGE` and `CUE`) and DASH output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)