### PR TITLE
ENG-4102: Defer to chunk-supplied ProgramDateTime when WSE has set one

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Refer to the guide in the [Resources](#resources) section for detailed instructi
 
 ## Build instructions
 * Clone repo to local filesystem.
-* Update `wseLibDir` variable in the `gradle.properties` file to point to local _Wowza Streaming Engine_ `lib` folder (`[install-dir]/lib`).
-* Run `./gradlew build` to build the jar file.
+* Run `./build.sh` to build the jar file using a docker container.
+* Copy the jar file to the lib folder of your Wowza Streaming Engine installation directory (`[install-dir]/lib`).
 
 ## Resources
 For full install instructions and to use the compiled version of these modules, see the following article:

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'com.wowza.wms.plugin.scte'
-version '1.1.3'
+version '1.2.0'
 
 java {
     toolchain {
@@ -23,8 +23,8 @@ dependencies {
     compileOnly 'com.wowza.wms:wms-server:4.9.2'
     compileOnly'com.wowza.wms:wms-httpstreamer-cupertinostreaming:4.9.2'
     compileOnly 'com.wowza.wms:wms-httpstreamer-mpegdashstreaming:4.9.2'
-    compileOnly 'org.apache.logging.log4j:log4j-core:2.17.2'
-    compileOnly 'org.apache.logging.log4j:log4j-api:2.17.2'
+    compileOnly 'org.apache.logging.log4j:log4j-core:2.25.3'
+    compileOnly 'org.apache.logging.log4j:log4j-api:2.25.3'
     testCompileOnly 'com.wowza.wms:wms-server:4.9.2'
     testCompileOnly 'com.wowza.wms:wms-httpstreamer-mpegdashstreaming:4.9.2'
 }

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+builddir="${1:-.}"
+
+if [ ! -f "$(realpath "$builddir")/gradlew" ]; then
+	echo "Error: gradlew not found ($(realpath "$builddir")/gradlew)"
+	exit 1
+fi
+
+gradle_cmd="${2:-build}"
+
+echo "${gradle_cmd}ing: $(realpath "$builddir")"
+docker run -it --platform linux/amd64 -v "$(realpath "$builddir")":/code  -e GRADLECMD="$gradle_cmd" wowza/wse-plugin-builder:4.10.0

--- a/src/main/java/com/wowza/wms/plugin/scte/LiveStreamPacketizerCupertinoDataHandler.java
+++ b/src/main/java/com/wowza/wms/plugin/scte/LiveStreamPacketizerCupertinoDataHandler.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.wowza.util.BufferUtils;
+import com.wowza.util.StringUtils;
 import com.wowza.wms.amf.*;
 import com.wowza.wms.httpstreamer.cupertinostreaming.livestreampacketizer.*;
 import com.wowza.wms.media.mp3.model.idtags.*;
@@ -51,18 +52,23 @@ public abstract class LiveStreamPacketizerCupertinoDataHandler extends LiveStrea
                     getClass().getSimpleName(), stream.getContextStr(), chunk.getRendition(), chunkStartTime, streamStartTime));
         }
 
-        Instant pdt = Instant.ofEpochMilli(streamStartTime + (chunkStartTime - tcOffsets[rendition - 1]));
-        Instant now = Instant.now();
-        Duration diff = Duration.between(pdt, now);
-        if (diff.abs().toMillis() > (long) liveStreamPacketizer.getChunkDurationTarget() * liveStreamPacketizer.getMaxChunkCount())
-        {
-            pdt = now;
-            tcOffsets[rendition - 1] = -1;
-        }
-        String programDateTime = dateTimeFormatter.format(pdt);
-        chunk.setProgramDateTime(programDateTime);
+        // From version 4.11, WSE is setting the programDateTime tag in the chunk, so we only need to set it if it's not already set.
+        String programDateTime = chunk.getProgramDateTime();
+		if (StringUtils.isEmpty(programDateTime))
+		{
+			Instant pdt = Instant.ofEpochMilli(streamStartTime + (chunkStartTime - tcOffsets[rendition - 1]));
+			Instant now = Instant.now();
+			Duration diff = Duration.between(pdt, now);
+			if (diff.abs().toMillis() > (long) liveStreamPacketizer.getChunkDurationTarget() * liveStreamPacketizer.getMaxChunkCount())
+			{
+				pdt = now;
+				tcOffsets[rendition - 1] = -1;
+			}
+			programDateTime = dateTimeFormatter.format(pdt);
+			chunk.setProgramDateTime(programDateTime);
+		}
 
-        ID3Frames id3Header = liveStreamPacketizer.getID3FramesHeader(chunk.getRendition());
+		ID3Frames id3Header = liveStreamPacketizer.getID3FramesHeader(chunk.getRendition());
         if (id3Header != null)
         {
             ID3V2FrameTextInformationUserDefined comment = new ID3V2FrameTextInformationUserDefined();


### PR DESCRIPTION
## Summary

- Fixes [ENG-4102](https://wowzamedia.jira.com/browse/ENG-4102): from WSE 4.11 the Cupertino packetizer sets `ProgramDateTime` on the chunk before `onFillChunkStart` runs. The plugin previously overwrote that value with its own (drift-corrected) calculation. Now it only falls back to the plugin's calculation when `chunk.getProgramDateTime()` is empty, preserving the WSE-supplied value otherwise.
- The ID3 `programDateTime` custom frame mirrors whichever PDT ends up on the chunk, so it stays consistent on both code paths.
- Older WSE (4.9.x / 4.10.x) behaviour is unchanged — `getProgramDateTime()` returns null on those versions so the plugin's existing calculation still runs.
- Drive-by: bumps plugin version to 1.2.0, bumps `log4j` compileOnly deps to 2.25.3, and adds a `build.sh` docker-based build helper (with matching `README.md` instructions) so users can build without a local WSE install.

## Test plan

- [x] `./gradlew build` — BUILD SUCCESSFUL.
- [ ] Run against WSE 4.11 with auto-PDT: confirm the `EXT-X-PROGRAM-DATE-TIME` in the playlist matches the WSE-supplied value and is not overwritten.
- [ ] Run against WSE 4.9.x / 4.10.x: confirm playlist PDT still comes from the plugin's calculation and the drift-recovery reset (`|pdt - now| > chunkDurationTarget * maxChunkCount`) still fires when expected.
- [ ] Cover both HLS tag modes (`scteAdsHlsTagType=DATERANGE` and `CUE`).
- [ ] Verify the ID3 `programDateTime` frame value matches the chunk's `EXT-X-PROGRAM-DATE-TIME` on both code paths.
- [ ] For DATERANGE mode: confirm `EXT-X-DATERANGE` `START-DATE` / `END-DATE` values remain consistent with the chunk PDT (no drift introduced by the new path).
- [ ] Validate `build.sh` builds a working JAR via the `wowza/wse-plugin-builder:4.10.0` image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)