### PR TITLE
ENG-4101: Round up when converting ptsAdjustment from 90 kHz ticks to ms

### DIFF
--- a/src/main/java/com/wowza/wms/plugin/scte/LiveStreamPacketizerCupertinoDataHandlerCue.java
+++ b/src/main/java/com/wowza/wms/plugin/scte/LiveStreamPacketizerCupertinoDataHandlerCue.java
@@ -34,7 +34,8 @@ public class LiveStreamPacketizerCupertinoDataHandlerCue extends LiveStreamPacke
                     if (!spliceOut)
                         return null;
                     AMFDataObj spliceTimeObj = eventObj.getObject("spliceTime");
-                    long spliceTimecode = spliceTimeObj.getLong("spliceTimeMS") + (data.getLong("ptsAdjustment") / 90);
+                    long ptsAdjustmentMs = (long)Math.ceil(data.getDouble("ptsAdjustment") / 90);
+                    long spliceTimecode = spliceTimeObj.getLong("spliceTimeMS") + ptsAdjustmentMs;
                     boolean durationFlag = eventObj.getBoolean("durationFlag");
                     long breakDuration = durationFlag ? (long) (eventObj.getDouble("breakDuration") / 90) : 0L;
                     if (breakDuration <= 0)

--- a/src/main/java/com/wowza/wms/plugin/scte/LiveStreamPacketizerCupertinoDataHandlerDateRange.java
+++ b/src/main/java/com/wowza/wms/plugin/scte/LiveStreamPacketizerCupertinoDataHandlerDateRange.java
@@ -46,7 +46,7 @@ public class LiveStreamPacketizerCupertinoDataHandlerDateRange extends LiveStrea
 				AMFDataObj eventObj = commandObj.getObject("event");
 				long eventId = eventObj.getLong("eventID");
 				boolean spliceOut = eventObj.getBoolean("outOfNetwork");
-				long ptsAdjustmentMs = data.getLong("ptsAdjustment") / 90;
+				long ptsAdjustmentMs = (long)Math.ceil(data.getDouble("ptsAdjustment") / 90);
 				if (spliceOut)
 				{
 					events.computeIfAbsent(eventId, id -> {


### PR DESCRIPTION
## Summary

- Follow-up to [#16](https://github.com/WowzaMediaSystems/wse-plugin-scte-ads/pull/16) / [ENG-4101](https://wowzamedia.jira.com/browse/ENG-4101). A customer reported the splice point landing a sub-millisecond fraction earlier than the true PTS.
- Root cause: `data.getLong("ptsAdjustment") / 90` performs integer division and truncates toward zero, so any `ptsAdjustment` value that isn't a multiple of 90 ticks loses up to 89/90 of a millisecond.
- Fix: read `ptsAdjustment` as a `double` and `Math.ceil(... / 90)` so the corrected splice time is never earlier than the real splice point. Applied in both HLS handlers (`...DataHandlerDateRange`, `...DataHandlerCue`). The DASH handler is unchanged — it operates in native 90 kHz ticks and never divides by 90.

## Test plan

- [x] `./gradlew build` — BUILD SUCCESSFUL.
- [ ] Replay the customer's feed and confirm `EXT-X-DATERANGE` `START-DATE` (and `EXT-X-CUE-OUT` time in CUE mode) is no longer earlier than the true splice point.
- [ ] Verify with a synthetic `ptsAdjustment` whose tick count is *not* a multiple of 90 (e.g. 91, 179) — pre-fix would have rounded down by one ms; post-fix rounds up.
- [ ] Regression with `ptsAdjustment = 0` and with exact multiples of 90 — no change in output.
- [ ] Confirm DASH output is unaffected (no change to that handler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)