### PR TITLE
Derive build version from release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
       discussions: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -53,7 +55,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Build Gradle
-        run: gradle build -Pversion=${{ github.ref_name }} -PwseLibDir=${{ vars.WSE_HOME }}/files/lib
+        run: gradle build -Prelease=true -PwseLibDir=${{ vars.WSE_HOME }}/files/lib
       - name: Release
         uses: softprops/action-gh-release@v2
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,18 @@
+import java.util.concurrent.Callable
+
 plugins {
     id 'java-library'
     id 'com.gorylenko.gradle-git-properties' version '2.5.2'
 }
 
 group 'com.wowza.wms.plugin.scte'
-version '1.2.0'
+
+Closure<String> resolveReleaseVersion = {
+    if (!project.ext.has('gitProps')) return 'unspecified'
+    String tags = project.ext.gitProps['git.tags'] as String
+    if (!tags) return 'unspecified'
+    return tags.split(',').find { it.matches(/\d+\.\d+\.\d+/) } ?: 'unspecified'
+}
 
 java {
     toolchain {
@@ -51,7 +59,7 @@ tasks.register('generateReleaseInfo') {
                 """|package $packageDotPath;
                    |public class ReleaseInfo {
                    |    public static String getProject() { return "${projectName}"; }
-                   |    public static String getVersion() { return "${project.version}"; }
+                   |    public static String getVersion() { return "${resolveReleaseVersion()}"; }
                    |    public static String getBuildComitDate() { return "${-> project.ext.gitProps['git.commit.time']}"; }
                    |    public static String getBuildNumber() { return "${-> project.ext.gitProps['git.commit.id.abbrev']}"; }
                    |}""".stripMargin()
@@ -63,12 +71,14 @@ clean.finalizedBy generateReleaseInfo
 compileJava.dependsOn generateReleaseInfo
 
 tasks.withType(Jar).configureEach {
+    dependsOn generateGitProperties
+    archiveVersion.set(project.provider({ resolveReleaseVersion() } as Callable<String>))
     manifest {
         attributes(
                 'Gradle-Version'        : "Gradle ${gradle.gradleVersion}",
                 'Created-By'      		: "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
                 'Name'                  : "${project.name}",
-                'Build-Version'	        : "${project.version}",
+                'Build-Version'	        : "${-> resolveReleaseVersion()}",
                 'Build-Timestamp'    	: "${-> project.ext.gitProps['git.commit.time']}",
                 'Build-Revision'        : "${-> project.ext.gitProps['git.commit.id.abbrev']}",
         )
@@ -78,6 +88,16 @@ tasks.withType(Jar).configureEach {
         from files('LICENSE.txt')
     }
     archiveBaseName = 'wse-plugin-' + projectName
+}
+
+tasks.named('jar').configure {
+    doFirst {
+        if (project.hasProperty('release') && resolveReleaseVersion() == 'unspecified') {
+            throw new GradleException(
+                    "Release build requires a *.*.* tag on HEAD; git.tags='${project.ext.gitProps?.get('git.tags') ?: ''}'"
+            )
+        }
+    }
 }
 
 test {


### PR DESCRIPTION
## Summary

- Removes the hardcoded `version '1.2.0'` from `build.gradle` — it was silently overriding the `-Pversion=<tag>` flag passed by the release workflow, so every published JAR shipped with the wrong version regardless of which tag triggered the release.
- Jar `archiveVersion`, manifest `Build-Version`, and `ReleaseInfo.getVersion()` now read `git.tags` from the existing `gradle-git-properties` plugin (first value matching `*.*.*` wins; falls back to `"unspecified"` for local dev builds).
- Release workflow opts in with `-Prelease=true`; a `doFirst` guard on the `jar` task fails loudly if no parseable tag is on HEAD, instead of silently shipping `wse-plugin-adinsertion-unspecified.jar`.
- Adds `fetch-depth: 0` to `actions/checkout@v4` so jgit can see the tag ref defensively.

## Test plan

- [x] `./gradlew clean build` on tag `1.2.1` → `wse-plugin-adinsertion-1.2.1.jar`; manifest `Build-Version: 1.2.1`; `ReleaseInfo.getVersion()` returns `1.2.1`.
- [x] `./gradlew clean jar -Prelease=true` with empty `git.tags` (simulated via init script) → build fails with `Release build requires a *.*.* tag on HEAD`.
- [x] `./gradlew clean build` (no `-Prelease`) with empty `git.tags` → `wse-plugin-adinsertion-unspecified.jar`, `Build-Version: unspecified`, build succeeds.
- [ ] After merge, cut a test tag matching `*.*.*` and confirm the release workflow uploads a JAR named with that tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)